### PR TITLE
Refactor and Test Fixes for RevenueCommand

### DIFF
--- a/src/main/java/seedu/edulog/logic/commands/PaidRevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/PaidRevenueCommand.java
@@ -1,19 +1,17 @@
 package seedu.edulog.logic.commands;
 
-import seedu.edulog.commons.util.ToStringBuilder;
-import seedu.edulog.logic.commands.exceptions.CommandException;
-import seedu.edulog.model.Model;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.edulog.model.Model.PREDICATE_SHOW_PAID_STUDENTS;
-import static seedu.edulog.model.Model.PREDICATE_SHOW_UNPAID_STUDENTS;
+
+import seedu.edulog.commons.util.ToStringBuilder;
+import seedu.edulog.model.Model;
 
 /**
  * Calculate total revenue earned
  */
 public class PaidRevenueCommand extends RevenueCommand {
 
-    private final String OPTION = "paid";
+    private final String option = "paid";
 
     public PaidRevenueCommand() { }
 
@@ -24,7 +22,7 @@ public class PaidRevenueCommand extends RevenueCommand {
         int result = model.getPaid();
         model.updateFilteredStudentList(PREDICATE_SHOW_PAID_STUDENTS);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, OPTION, result));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, option, result));
     }
 
     @Override

--- a/src/main/java/seedu/edulog/logic/commands/PaidRevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/PaidRevenueCommand.java
@@ -5,58 +5,35 @@ import seedu.edulog.logic.commands.exceptions.CommandException;
 import seedu.edulog.model.Model;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.edulog.model.Model.*;
+import static seedu.edulog.model.Model.PREDICATE_SHOW_PAID_STUDENTS;
+import static seedu.edulog.model.Model.PREDICATE_SHOW_UNPAID_STUDENTS;
 
 /**
  * Calculate total revenue earned
  */
-public class RevenueCommand extends Command {
-    public static final String COMMAND_WORD = "revenue";
-    public static final String COMMAND_USAGE = COMMAND_WORD + " [paid/unpaid]"
-            + ": calculate total amount of money earned/not earned"
-            + "from students who have paid/not paid. Example: revenue paid";
-    public static final String COMMAND_SUCCESS = "Total revenue %s is $%d";
-    public static final String MESSAGE_SUCCESS = "Total revenue %s is $%d";
-    public static final String PAID = "paid";
-    public static final String UNPAID = "unpaid";
+public class PaidRevenueCommand extends RevenueCommand {
 
-    private String option;
+    private final String OPTION = "paid";
 
-    public RevenueCommand(String option) {
-        this.option = option;
-    }
+    public PaidRevenueCommand() { }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        int result;
-        if (option.equals(PAID)) {
-            model.updateFilteredStudentList(PREDICATE_SHOW_PAID_STUDENTS);
-            result = model.getPaid();
-        } else if (option.equals(UNPAID)) {
-            model.updateFilteredStudentList(PREDICATE_SHOW_UNPAID_STUDENTS);
-            result = model.getUnpaid();
-        } else {
-            throw new CommandException();
-        }
+        int result = model.getPaid();
+        model.updateFilteredStudentList(PREDICATE_SHOW_PAID_STUDENTS);
 
-        String output = String.format(COMMAND_SUCCESS, option, result);
-        return new CommandResult(output);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, OPTION, result));
     }
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof RevenueCommand)) {
-            return false;
-        }
-
-        RevenueCommand otherCommand = (RevenueCommand) other;
-        return otherCommand.option.equals(this.option);
+        return (other instanceof PaidRevenueCommand);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("option", option).toString();
+        return new ToStringBuilder(this).toString();
     }
 }

--- a/src/main/java/seedu/edulog/logic/commands/PaidRevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/PaidRevenueCommand.java
@@ -1,0 +1,62 @@
+package seedu.edulog.logic.commands;
+
+import seedu.edulog.commons.util.ToStringBuilder;
+import seedu.edulog.logic.commands.exceptions.CommandException;
+import seedu.edulog.model.Model;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.edulog.model.Model.*;
+
+/**
+ * Calculate total revenue earned
+ */
+public class RevenueCommand extends Command {
+    public static final String COMMAND_WORD = "revenue";
+    public static final String COMMAND_USAGE = COMMAND_WORD + " [paid/unpaid]"
+            + ": calculate total amount of money earned/not earned"
+            + "from students who have paid/not paid. Example: revenue paid";
+    public static final String COMMAND_SUCCESS = "Total revenue %s is $%d";
+    public static final String MESSAGE_SUCCESS = "Total revenue %s is $%d";
+    public static final String PAID = "paid";
+    public static final String UNPAID = "unpaid";
+
+    private String option;
+
+    public RevenueCommand(String option) {
+        this.option = option;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        int result;
+        if (option.equals(PAID)) {
+            model.updateFilteredStudentList(PREDICATE_SHOW_PAID_STUDENTS);
+            result = model.getPaid();
+        } else if (option.equals(UNPAID)) {
+            model.updateFilteredStudentList(PREDICATE_SHOW_UNPAID_STUDENTS);
+            result = model.getUnpaid();
+        } else {
+            throw new CommandException();
+        }
+
+        String output = String.format(COMMAND_SUCCESS, option, result);
+        return new CommandResult(output);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof RevenueCommand)) {
+            return false;
+        }
+
+        RevenueCommand otherCommand = (RevenueCommand) other;
+        return otherCommand.option.equals(this.option);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("option", option).toString();
+    }
+}

--- a/src/main/java/seedu/edulog/logic/commands/RevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/RevenueCommand.java
@@ -1,11 +1,7 @@
 package seedu.edulog.logic.commands;
 
-import seedu.edulog.commons.util.ToStringBuilder;
 import seedu.edulog.logic.commands.exceptions.CommandException;
 import seedu.edulog.model.Model;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.edulog.model.Model.*;
 
 /**
  * Calculate total revenue earned

--- a/src/main/java/seedu/edulog/logic/commands/RevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/RevenueCommand.java
@@ -4,43 +4,24 @@ import seedu.edulog.commons.util.ToStringBuilder;
 import seedu.edulog.logic.commands.exceptions.CommandException;
 import seedu.edulog.model.Model;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.edulog.model.Model.*;
+
 /**
  * Calculate total revenue earned
  */
-public class RevenueCommand extends Command {
+public abstract class RevenueCommand extends Command {
     public static final String COMMAND_WORD = "revenue";
     public static final String COMMAND_USAGE = COMMAND_WORD + " [paid/unpaid]"
             + ": calculate total amount of money earned/not earned"
             + "from students who have paid/not paid. Example: revenue paid";
-    public static final String COMMAND_SUCCESS = "Total revenue %s is $%d";
+    public static final String MESSAGE_SUCCESS = "Total revenue %s is $%d";
     public static final String PAID = "paid";
     public static final String UNPAID = "unpaid";
 
-    private String option;
-
-    public RevenueCommand(String option) {
-        this.option = option;
-    }
+    @Override
+    public abstract CommandResult execute(Model model) throws CommandException;
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
-        int result = (option.equals(PAID)) ? model.getPaid() : model.getUnpaid();
-        String output = String.format(COMMAND_SUCCESS, option, result);
-        return new CommandResult(output);
-    }
-
-    @Override
-    public boolean equals(Object other) {
-        if (!(other instanceof RevenueCommand)) {
-            return false;
-        }
-
-        RevenueCommand otherCommand = (RevenueCommand) other;
-        return otherCommand.option.equals(this.option);
-    }
-
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this).add("option", option).toString();
-    }
+    public abstract String toString();
 }

--- a/src/main/java/seedu/edulog/logic/commands/UnpaidRevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/UnpaidRevenueCommand.java
@@ -1,0 +1,63 @@
+package seedu.edulog.logic.commands;
+
+import seedu.edulog.commons.util.ToStringBuilder;
+import seedu.edulog.logic.commands.exceptions.CommandException;
+import seedu.edulog.model.Model;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.edulog.model.Model.PREDICATE_SHOW_PAID_STUDENTS;
+import static seedu.edulog.model.Model.PREDICATE_SHOW_UNPAID_STUDENTS;
+
+/**
+ * Calculate total revenue earned
+ */
+public class PaidRevenueCommand extends Command {
+    public static final String COMMAND_WORD = "revenue";
+    public static final String COMMAND_USAGE = COMMAND_WORD + " [paid/unpaid]"
+            + ": calculate total amount of money earned/not earned"
+            + "from students who have paid/not paid. Example: revenue paid";
+    public static final String COMMAND_SUCCESS = "Total revenue %s is $%d";
+    public static final String MESSAGE_SUCCESS = "Total revenue %s is $%d";
+    public static final String PAID = "paid";
+    public static final String UNPAID = "unpaid";
+
+    private String option;
+
+    public PaidRevenueCommand(String option) {
+        this.option = option;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        int result;
+        if (option.equals(PAID)) {
+            model.updateFilteredStudentList(PREDICATE_SHOW_PAID_STUDENTS);
+            result = model.getPaid();
+        } else if (option.equals(UNPAID)) {
+            model.updateFilteredStudentList(PREDICATE_SHOW_UNPAID_STUDENTS);
+            result = model.getUnpaid();
+        } else {
+            throw new CommandException();
+        }
+
+        String output = String.format(COMMAND_SUCCESS, option, result);
+        return new CommandResult(output);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (!(other instanceof PaidRevenueCommand)) {
+            return false;
+        }
+
+        PaidRevenueCommand otherCommand = (PaidRevenueCommand) other;
+        return otherCommand.option.equals(this.option);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("option", option).toString();
+    }
+}

--- a/src/main/java/seedu/edulog/logic/commands/UnpaidRevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/UnpaidRevenueCommand.java
@@ -1,19 +1,17 @@
 package seedu.edulog.logic.commands;
 
-import seedu.edulog.commons.util.ToStringBuilder;
-import seedu.edulog.logic.commands.exceptions.CommandException;
-import seedu.edulog.model.Model;
-
 import static java.util.Objects.requireNonNull;
-import static seedu.edulog.model.Model.PREDICATE_SHOW_PAID_STUDENTS;
 import static seedu.edulog.model.Model.PREDICATE_SHOW_UNPAID_STUDENTS;
+
+import seedu.edulog.commons.util.ToStringBuilder;
+import seedu.edulog.model.Model;
 
 /**
  * Calculate total revenue earned
  */
 public class UnpaidRevenueCommand extends RevenueCommand {
 
-    private final String OPTION = "unpaid";
+    private final String option = "unpaid";
 
     public UnpaidRevenueCommand() { }
 
@@ -24,7 +22,7 @@ public class UnpaidRevenueCommand extends RevenueCommand {
         int result = model.getUnpaid();
         model.updateFilteredStudentList(PREDICATE_SHOW_UNPAID_STUDENTS);
 
-        return new CommandResult(String.format(MESSAGE_SUCCESS, OPTION, result));
+        return new CommandResult(String.format(MESSAGE_SUCCESS, option, result));
     }
 
     @Override

--- a/src/main/java/seedu/edulog/logic/commands/UnpaidRevenueCommand.java
+++ b/src/main/java/seedu/edulog/logic/commands/UnpaidRevenueCommand.java
@@ -11,53 +11,29 @@ import static seedu.edulog.model.Model.PREDICATE_SHOW_UNPAID_STUDENTS;
 /**
  * Calculate total revenue earned
  */
-public class PaidRevenueCommand extends Command {
-    public static final String COMMAND_WORD = "revenue";
-    public static final String COMMAND_USAGE = COMMAND_WORD + " [paid/unpaid]"
-            + ": calculate total amount of money earned/not earned"
-            + "from students who have paid/not paid. Example: revenue paid";
-    public static final String COMMAND_SUCCESS = "Total revenue %s is $%d";
-    public static final String MESSAGE_SUCCESS = "Total revenue %s is $%d";
-    public static final String PAID = "paid";
-    public static final String UNPAID = "unpaid";
+public class UnpaidRevenueCommand extends RevenueCommand {
 
-    private String option;
+    private final String OPTION = "unpaid";
 
-    public PaidRevenueCommand(String option) {
-        this.option = option;
-    }
+    public UnpaidRevenueCommand() { }
 
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) {
         requireNonNull(model);
 
-        int result;
-        if (option.equals(PAID)) {
-            model.updateFilteredStudentList(PREDICATE_SHOW_PAID_STUDENTS);
-            result = model.getPaid();
-        } else if (option.equals(UNPAID)) {
-            model.updateFilteredStudentList(PREDICATE_SHOW_UNPAID_STUDENTS);
-            result = model.getUnpaid();
-        } else {
-            throw new CommandException();
-        }
+        int result = model.getUnpaid();
+        model.updateFilteredStudentList(PREDICATE_SHOW_UNPAID_STUDENTS);
 
-        String output = String.format(COMMAND_SUCCESS, option, result);
-        return new CommandResult(output);
+        return new CommandResult(String.format(MESSAGE_SUCCESS, OPTION, result));
     }
 
     @Override
     public boolean equals(Object other) {
-        if (!(other instanceof PaidRevenueCommand)) {
-            return false;
-        }
-
-        PaidRevenueCommand otherCommand = (PaidRevenueCommand) other;
-        return otherCommand.option.equals(this.option);
+        return (other instanceof UnpaidRevenueCommand);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("option", option).toString();
+        return new ToStringBuilder(this).toString();
     }
 }

--- a/src/main/java/seedu/edulog/logic/parser/RevenueCommandParser.java
+++ b/src/main/java/seedu/edulog/logic/parser/RevenueCommandParser.java
@@ -1,12 +1,11 @@
 package seedu.edulog.logic.parser;
 
+import static seedu.edulog.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
 import seedu.edulog.logic.commands.PaidRevenueCommand;
 import seedu.edulog.logic.commands.RevenueCommand;
-import seedu.edulog.logic.commands.UnmarkCommand;
 import seedu.edulog.logic.commands.UnpaidRevenueCommand;
 import seedu.edulog.logic.parser.exceptions.ParseException;
-
-import static seedu.edulog.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguements so RevenueCommand knows whether to show total paid or unpaid

--- a/src/main/java/seedu/edulog/logic/parser/RevenueCommandParser.java
+++ b/src/main/java/seedu/edulog/logic/parser/RevenueCommandParser.java
@@ -1,7 +1,12 @@
 package seedu.edulog.logic.parser;
 
+import seedu.edulog.logic.commands.PaidRevenueCommand;
 import seedu.edulog.logic.commands.RevenueCommand;
+import seedu.edulog.logic.commands.UnmarkCommand;
+import seedu.edulog.logic.commands.UnpaidRevenueCommand;
 import seedu.edulog.logic.parser.exceptions.ParseException;
+
+import static seedu.edulog.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 /**
  * Parses input arguements so RevenueCommand knows whether to show total paid or unpaid
@@ -11,13 +16,15 @@ public class RevenueCommandParser implements Parser<RevenueCommand> {
      * Parses the option and returns the configured RevenueCommand
      */
     public RevenueCommand parse(String args) throws ParseException {
+
         args = args.trim();
         if (args.equals(RevenueCommand.PAID)) {
-            return new RevenueCommand("paid");
+            return new PaidRevenueCommand();
         } else if (args.equals(RevenueCommand.UNPAID)) {
-            return new RevenueCommand(("unpaid"));
+            return new UnpaidRevenueCommand();
         } else {
-            throw new ParseException(RevenueCommand.COMMAND_USAGE);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
         }
+
     }
 }

--- a/src/main/java/seedu/edulog/model/Model.java
+++ b/src/main/java/seedu/edulog/model/Model.java
@@ -17,6 +17,12 @@ public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Student> PREDICATE_SHOW_ALL_STUDENTS = unused -> true;
 
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Student> PREDICATE_SHOW_PAID_STUDENTS = student -> student.getHasPaid();
+
+    /** {@code Predicate} that always evaluate to true */
+    Predicate<Student> PREDICATE_SHOW_UNPAID_STUDENTS = student -> !student.getHasPaid();
+
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
      */

--- a/src/test/java/seedu/edulog/logic/commands/RevenueCommandTest.java
+++ b/src/test/java/seedu/edulog/logic/commands/RevenueCommandTest.java
@@ -16,43 +16,43 @@ public class RevenueCommandTest {
 
     @Test
     public void execute_noHasPaidOptionPaid_successful() {
-        RevenueCommand command = new RevenueCommand("paid");
+        RevenueCommand command = new PaidRevenueCommand();
         Model model = new ModelManager(getTypicalEduLogWithCopiedStudents(), new UserPrefs());
         model.unmarkAllStudents();
 
         // none of the student has paid
-        String expectedMessage = String.format(RevenueCommand.COMMAND_SUCCESS, "paid", 0);
+        String expectedMessage = String.format(RevenueCommand.MESSAGE_SUCCESS, "paid", 0);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 
     @Test
     public void execute_allHasPaidOptionPaid_successful() {
-        RevenueCommand command = new RevenueCommand("paid");
+        RevenueCommand command = new PaidRevenueCommand();
         Model model = new ModelManager(getTypicalEduLogWithCopiedStudents(), new UserPrefs());
         model.markAllStudents();
 
-        String expectedMessage = String.format(RevenueCommand.COMMAND_SUCCESS, "paid", 700);
+        String expectedMessage = String.format(RevenueCommand.MESSAGE_SUCCESS, "paid", 700);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 
     @Test
     public void execute_noHasPaidOptionUnpaid_successful() {
-        RevenueCommand command = new RevenueCommand("unpaid");
+        RevenueCommand command = new UnpaidRevenueCommand();
         Model model = new ModelManager(getTypicalEduLogWithCopiedStudents(), new UserPrefs());
         model.unmarkAllStudents();
 
         // none of the student has paid
-        String expectedMessage = String.format(RevenueCommand.COMMAND_SUCCESS, "unpaid", 700);
+        String expectedMessage = String.format(RevenueCommand.MESSAGE_SUCCESS, "unpaid", 700);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 
     @Test
     public void execute_allHasPaidOptionUnpaid_successful() {
-        RevenueCommand command = new RevenueCommand("unpaid");
+        RevenueCommand command = new UnpaidRevenueCommand();
         Model model = new ModelManager(getTypicalEduLogWithCopiedStudents(), new UserPrefs());
         model.markAllStudents();
 
-        String expectedMessage = String.format(RevenueCommand.COMMAND_SUCCESS, "unpaid", 0);
+        String expectedMessage = String.format(RevenueCommand.MESSAGE_SUCCESS, "unpaid", 0);
         assertCommandSuccess(command, model, expectedMessage, model);
     }
 }

--- a/src/test/java/seedu/edulog/logic/parser/RevenueCommandParserTest.java
+++ b/src/test/java/seedu/edulog/logic/parser/RevenueCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.edulog.logic.parser;
 
+import static seedu.edulog.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.edulog.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.edulog.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
@@ -21,8 +22,8 @@ public class RevenueCommandParserTest {
 
     @Test
     public void parse_invalidArgs() {
-        assertParseFailure(parser, "paid unpaid", RevenueCommand.COMMAND_USAGE);
-        assertParseFailure(parser, "12345", RevenueCommand.COMMAND_USAGE);
-        assertParseFailure(parser, "paid 123", RevenueCommand.COMMAND_USAGE);
+        assertParseFailure(parser, "paid unpaid", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
+        assertParseFailure(parser, "12345", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
+        assertParseFailure(parser, "paid 123", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
     }
 }

--- a/src/test/java/seedu/edulog/logic/parser/RevenueCommandParserTest.java
+++ b/src/test/java/seedu/edulog/logic/parser/RevenueCommandParserTest.java
@@ -5,7 +5,9 @@ import static seedu.edulog.logic.parser.CommandParserTestUtil.assertParseSuccess
 
 import org.junit.jupiter.api.Test;
 
+import seedu.edulog.logic.commands.PaidRevenueCommand;
 import seedu.edulog.logic.commands.RevenueCommand;
+import seedu.edulog.logic.commands.UnpaidRevenueCommand;
 
 
 public class RevenueCommandParserTest {
@@ -13,8 +15,8 @@ public class RevenueCommandParserTest {
 
     @Test
     public void parse_validArgs_successful() {
-        assertParseSuccess(parser, "paid", new RevenueCommand("paid"));
-        assertParseSuccess(parser, "unpaid", new RevenueCommand("unpaid"));
+        assertParseSuccess(parser, "paid", new PaidRevenueCommand());
+        assertParseSuccess(parser, "unpaid", new UnpaidRevenueCommand());
     }
 
     @Test

--- a/src/test/java/seedu/edulog/logic/parser/RevenueCommandParserTest.java
+++ b/src/test/java/seedu/edulog/logic/parser/RevenueCommandParserTest.java
@@ -22,8 +22,11 @@ public class RevenueCommandParserTest {
 
     @Test
     public void parse_invalidArgs() {
-        assertParseFailure(parser, "paid unpaid", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
-        assertParseFailure(parser, "12345", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
-        assertParseFailure(parser, "paid 123", String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
+        assertParseFailure(parser, "paid unpaid",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
+        assertParseFailure(parser, "12345",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
+        assertParseFailure(parser, "paid 123",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevenueCommand.COMMAND_USAGE));
     }
 }


### PR DESCRIPTION
Fixes #161 
Fixes #130

1. **Refactored `RevenueCommand` into an Abstract Class**  
   - Converted `RevenueCommand` to an abstract class, centralizing shared logic.
   - Reduced coupling and improved maintainability.

2. **Added `PaidRevenueCommand` and `UnpaidRevenueCommand`**  
   - Created `PaidRevenueCommand` and `UnpaidRevenueCommand` to handle specific revenue types.
   - Improved clarity and separation of responsibilities for revenue-related commands.

3. **Fixed Tests Post-OOP Refactor of `RevenueCommand`**  
   - Updated and fixed tests to align with the new structure.
   - Confirmed all tests pass to ensure stability of the refactor.

4. **Tests have been adjusted for the new class structure**  